### PR TITLE
#10 Implement manual variable injection

### DIFF
--- a/rxgemini/fetcher.py
+++ b/rxgemini/fetcher.py
@@ -24,6 +24,28 @@ SAVE_DIR = CONFIG["SAVE_DIRECTORY"]
 LOG_MODE = CONFIG["LOG_MODE"]
 
 
+def get_args_dict(
+        fn: callable,
+        args: list, kwargs: dict, is_method: bool = False) -> dict:
+    """
+    Fetches data values from function
+
+    Args:
+        fn (callable): _description_
+        args (list): _description_
+        kwargs (dict): _description_
+        is_method (bool, optional): _description_. Defaults to False.
+
+    Returns:
+        dict: _description_
+    """   
+    if is_method:
+        args_names = fn.__code__.co_varnames[1: fn.__code__.co_argcount]
+    else:
+        args_names = fn.__code__.co_varnames[: fn.__code__.co_argcount]
+    return {**dict(zip(args_names, args), **kwargs)}
+
+
 def call_data_handler(
         func: callable,
         args: list,

--- a/rxgemini/injector.py
+++ b/rxgemini/injector.py
@@ -3,6 +3,7 @@
 import functools
 import inspect
 import pathlib
+import sys
 
 import typer
 
@@ -44,7 +45,7 @@ def auto_injector(func):
                     # may add support for comma imports and import ()
                     if "," in line:
                         typer.echo("error")
-                        exit()
+                        sys.exit()
                     line = line.replace("from", "")
                     line = line.replace(lookup_val, "")
                     line = line.replace("import", "")

--- a/rxgemini/injector.py
+++ b/rxgemini/injector.py
@@ -1,6 +1,5 @@
 """Injection module for RX Gemini"""
 
-# TODO: refactor
 import functools
 import inspect
 import pathlib
@@ -26,6 +25,10 @@ def metadata_reader(filename: str):
 
 def pickle_reader(filename: str):
     log_info(filename)
+
+
+def retrive_test_data(method_identifier: str):
+    log_info(f"Gathering data for {method_identifier}")
 
 
 def auto_injector(func):

--- a/rxgemini/injector.py
+++ b/rxgemini/injector.py
@@ -1,7 +1,6 @@
 """Injection module for RX Gemini"""
 
-# pylint: skip-file
-# Skipping file because it has a pending refactor
+# TODO: refactor
 import functools
 import inspect
 import pathlib

--- a/rxgemini/injector.py
+++ b/rxgemini/injector.py
@@ -10,8 +10,10 @@ import typer
 
 from rxgemini.configurator import config_checker
 from rxgemini.log_handler import log_warning, log_info
+from rxgemini.constants import EXT
 
 CONFIG = config_checker(internal=True)
+SAVE_DIR = CONFIG["SAVE_DIRECTORY"]
 
 
 def path_handler_for_tests():
@@ -29,8 +31,12 @@ def pickle_reader(filename: str):
 
 def retrive_test_data(method_identifier: str):
     log_info(f"Gathering data for {method_identifier}")
+    data_path = pathlib.Path().joinpath(SAVE_DIR, method_identifier)
+    data_files = [f for f in data_path.glob(f"*{EXT}")]
+    print(data_files)
 
 
+# This is for next ticket, ignore for now
 def auto_injector(func):
     @functools.wraps(func)
     def wrapper_injector(*args):

--- a/rxgemini/injector.py
+++ b/rxgemini/injector.py
@@ -30,10 +30,10 @@ def pickle_reader(filename: str):
 
 
 def retrive_test_data(method_identifier: str):
-    log_info(f"Gathering data for {method_identifier}")
+    log_info(f"Gathering data for {method_identifier} tests")
     data_path = pathlib.Path().joinpath(SAVE_DIR, method_identifier)
     data_files = [f for f in data_path.glob(f"*{EXT}")]
-    print(data_files)
+    log_info(f"Found {data_files} data points.")
 
 
 # This is for next ticket, ignore for now

--- a/rxgemini/injector.py
+++ b/rxgemini/injector.py
@@ -11,7 +11,6 @@ from rxgemini.configurator import config_checker
 from rxgemini.log_handler import log_warning, log_info
 
 CONFIG = config_checker(internal=True)
-META_LABEL = CONFIG["META_LABEL"]
 
 
 def path_handler_for_tests():
@@ -58,7 +57,7 @@ def auto_injector(func):
         checker = path_handler_for_tests()
         log_info(f"Fetching from{ obj_path}")
         # metadata path will need refactoring to work on windows hosts
-        metadata = metadata_reader(f"{checker}/{lookup_val}{META_LABEL}.json")
+        metadata = metadata_reader(f"{checker}/{lookup_val}META.json")
         test_data = {
             "in": pickle_reader(metadata["IN"]),
             "out": pickle_reader(metadata["OUT"]),

--- a/test/test_injector.py
+++ b/test/test_injector.py
@@ -1,0 +1,26 @@
+"""Test Module for injector"""
+
+import unittest
+
+from rxgemini.injector import (
+    path_handler_for_tests
+)
+
+
+class TestInjector(unittest.TestCase):
+    """
+    Tests methods/functions from rxgemini/fetcher.py
+
+    Args:
+        unittest (class): Inherits from TestCase
+    """
+
+    def test_path_handler_for_tests(self):
+        """
+        Tests Path handler function
+        """
+        self.assertIsInstance(path_handler_for_tests(), int)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_injector.py
+++ b/test/test_injector.py
@@ -9,7 +9,7 @@ from rxgemini.injector import (
 
 class TestInjector(unittest.TestCase):
     """
-    Tests methods/functions from rxgemini/fetcher.py
+    Tests methods/functions from rxgemini/injector.py
 
     Args:
         unittest (class): Inherits from TestCase


### PR DESCRIPTION
Inject variables manually without the use of a decorator to add them. Allow user to use dot notation to access sets of inputs and outputs

provide groundwork to have general purpose injection methods. 